### PR TITLE
Fix max_channels validation with ESPHome 2025.6

### DIFF
--- a/esphome/components/adf_pipeline/media_player/__init__.py
+++ b/esphome/components/adf_pipeline/media_player/__init__.py
@@ -20,7 +20,7 @@ ADFMediaPlayer = esp_adf_ns.class_(
     "ADFMediaPlayer", ADFPipelineController, media_player.MediaPlayer, cg.Component
 )
 
-CONFIG_SCHEMA = media_player.MEDIA_PLAYER_SCHEMA.extend(
+CONFIG_SCHEMA = media_player.media_player_schema(
     {
         cv.GenerateID(): cv.declare_id(ADFMediaPlayer),
     }

--- a/esphome/components/adf_pipeline/microphone/__init__.py
+++ b/esphome/components/adf_pipeline/microphone/__init__.py
@@ -35,4 +35,12 @@ async def to_code(config):
     cg.add(var.set_gain_log2(config[CONF_GAIN_LOG_2]))
     await cg.register_component(var, config)
     await setup_pipeline_controller(var, config)
-    await microphone.register_microphone(var, config)
+    audio_device = {"max_channels": 2}
+    try:
+        await microphone.register_microphone(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    except TypeError:
+        await microphone.register_microphone(var, config)

--- a/esphome/components/adf_pipeline/speaker/__init__.py
+++ b/esphome/components/adf_pipeline/speaker/__init__.py
@@ -33,4 +33,12 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await setup_pipeline_controller(var, config)
-    await speaker.register_speaker(var, config)
+    audio_device = {"max_channels": 2}
+    try:
+        await speaker.register_speaker(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    except TypeError:
+        await speaker.register_speaker(var, config)

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -117,4 +117,12 @@ async def to_code(config):
         # cg.add(var.set_pdm(config[CONF_PDM]))
         await register_i2s_reader(var, config)
 
-    await microphone.register_microphone(var, config)
+    audio_device = {"max_channels": 2}
+    try:
+        await microphone.register_microphone(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    except TypeError:
+        await microphone.register_microphone(var, config)

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -87,7 +87,15 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await speaker.register_speaker(var, config)
+    audio_device = {"max_channels": 2}
+    try:
+        await speaker.register_speaker(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    except TypeError:
+        await speaker.register_speaker(var, config)
 
     await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
 


### PR DESCRIPTION
## Summary
- default `audio_device` when registering speakers or microphones
- replace deprecated `MEDIA_PLAYER_SCHEMA` with `media_player.media_player_schema`

## Testing
- `pytest -q`
- `python3 -m ci_esph test` *(fails: ModuleNotFoundError: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_685fc1c2aa30833195d01ca209e1cf3c