### PR TITLE
Fix max_channels validation for newer ESPHome

### DIFF
--- a/esphome/components/adf_pipeline/media_player/__init__.py
+++ b/esphome/components/adf_pipeline/media_player/__init__.py
@@ -20,11 +20,9 @@ ADFMediaPlayer = esp_adf_ns.class_(
     "ADFMediaPlayer", ADFPipelineController, media_player.MediaPlayer, cg.Component
 )
 
-CONFIG_SCHEMA = media_player.MEDIA_PLAYER_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(ADFMediaPlayer),
-    }
-).extend(ADF_PIPELINE_CONTROLLER_SCHEMA)
+CONFIG_SCHEMA = media_player.media_player_schema(ADFMediaPlayer).extend(
+    ADF_PIPELINE_CONTROLLER_SCHEMA
+)
 
 
 # @coroutine_with_priority(100.0)

--- a/esphome/components/adf_pipeline/microphone/__init__.py
+++ b/esphome/components/adf_pipeline/microphone/__init__.py
@@ -3,6 +3,7 @@
 import esphome.codegen as cg
 from esphome.components import microphone
 import esphome.config_validation as cv
+import inspect
 from esphome.const import CONF_ID
 
 from .. import (
@@ -35,4 +36,12 @@ async def to_code(config):
     cg.add(var.set_gain_log2(config[CONF_GAIN_LOG_2]))
     await cg.register_component(var, config)
     await setup_pipeline_controller(var, config)
-    await microphone.register_microphone(var, config)
+    audio_device = {"max_channels": 1}
+    if "audio_device" in inspect.signature(microphone.register_microphone).parameters:
+        await microphone.register_microphone(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    else:
+        await microphone.register_microphone(var, config)

--- a/esphome/components/adf_pipeline/speaker/__init__.py
+++ b/esphome/components/adf_pipeline/speaker/__init__.py
@@ -3,6 +3,7 @@
 import esphome.codegen as cg
 from esphome.components import speaker
 import esphome.config_validation as cv
+import inspect
 from esphome.const import CONF_ID
 
 from .. import (
@@ -33,4 +34,12 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await setup_pipeline_controller(var, config)
-    await speaker.register_speaker(var, config)
+    audio_device = {"max_channels": 2}
+    if "audio_device" in inspect.signature(speaker.register_speaker).parameters:
+        await speaker.register_speaker(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    else:
+        await speaker.register_speaker(var, config)

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -1,5 +1,6 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
+import inspect
 
 from esphome import pins
 from esphome.const import CONF_CHANNEL, CONF_ID, CONF_MODEL, CONF_NUMBER
@@ -117,4 +118,12 @@ async def to_code(config):
         # cg.add(var.set_pdm(config[CONF_PDM]))
         await register_i2s_reader(var, config)
 
-    await microphone.register_microphone(var, config)
+    audio_device = {"max_channels": 1}
+    if "audio_device" in inspect.signature(microphone.register_microphone).parameters:
+        await microphone.register_microphone(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    else:
+        await microphone.register_microphone(var, config)

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import inspect
 from esphome import pins
 from esphome.const import CONF_ID, CONF_MODE, CONF_MODEL
 from esphome.components import esp32, speaker
@@ -87,7 +88,15 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await speaker.register_speaker(var, config)
+    audio_device = {"max_channels": 2 if config[CONF_MODE] == "stereo" else 1}
+    if "audio_device" in inspect.signature(speaker.register_speaker).parameters:
+        await speaker.register_speaker(
+            var,
+            config,
+            audio_device=audio_device,
+        )
+    else:
+        await speaker.register_speaker(var, config)
 
     await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
 


### PR DESCRIPTION
## Summary
- default audio_device only when the API expects it to maintain backward compatibility
- compute channel count for I2S speakers
- use new `media_player.media_player_schema`
- fix wrong CONFIG_SCHEMA call

## Testing
- `pytest -q`
- `python3 -m ci_esph test` *(fails: At least one platform must be specified for 'ota')*

------
https://chatgpt.com/codex/tasks/task_e_685fc1c2aa30833195d01ca209e1cf3c